### PR TITLE
fix/URL

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,7 +160,7 @@ export default function Dashboard() {
                                             </div>
                                         ))}
                                         <div className="flex justify-center">
-                                            <Link href="/sessions" className="text-blue-600 text-sm">
+                                            <Link href="/schedule" className="text-blue-600 text-sm">
                                                 セッション一覧を見る
                                             </Link>
                                         </div>


### PR DESCRIPTION
## 💻概要
### 機能名
ダッシュボードページ上の「セッション一覧を見る」から遷移するURLを現在のものに修正
### 📸スクリーンショット
- 遷移前
<img width="410" height="456" alt="image" src="https://github.com/user-attachments/assets/493e7bf2-b1d5-472d-8257-b3149d351d67" />

- 遷移後
<img width="913" height="748" alt="image" src="https://github.com/user-attachments/assets/60bf30f2-188f-4975-ba8b-8abab4666c8a" />

## 📄修正内容
URLをもとの状態の[/session]から現在の[/schedule]に修正
## 👀動作確認
ダッシュボードページ上の「セッション一覧を見る」を押下する。遷移後に404ではなく【/schedule】に遷移されているかを確認
## ❌現存エラー
なし
## 📝補足
なし
## 📄参考資料
なし